### PR TITLE
label verwijderd

### DIFF
--- a/src/lib/components/checklist.svelte
+++ b/src/lib/components/checklist.svelte
@@ -145,12 +145,14 @@
 						{#if succescriterium.niveau === selectedNiveau}
 							<details>
 								<summary class="criteria-uitklapbaar">
-										<div class="titels">
-											<span>Criteria {succescriterium.index} ({succescriterium.niveau})</span>
+									<span>Criteria {succescriterium.index} ({succescriterium.niveau})</span>
+									<div class="row">
+									<div class="column">
 											<h3>{succescriterium.titel}</h3>
-										</div>
+									</div>
 
-										<button 
+									<div class="column">
+										<button
                                             type="button" 
                                             class="btn-vertaling" 
                                             on:click={(event) => translate(event, succescriterium.index)}
@@ -164,6 +166,8 @@
 											type="checkbox"
 											checked={checkedSuccescriteria.find((e) => e.id === succescriterium.id)}
 										/>
+									</div>
+								</div>
 								</summary>
 								<!-- tekuitleg voor succescriterium -->
 
@@ -387,6 +391,20 @@
 		/* display: flex; */
 		flex-direction: row;
 		align-items: center;
+	}
+
+	.row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.column {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: 1rem;
 	}
 
 	/* .criteria-uitklapbaar::-webkit-details-marker {

--- a/src/lib/components/checklist.svelte
+++ b/src/lib/components/checklist.svelte
@@ -145,7 +145,6 @@
 						{#if succescriterium.niveau === selectedNiveau}
 							<details>
 								<summary class="criteria-uitklapbaar">
-									<label>
 										<div class="titels">
 											<span>Criteria {succescriterium.index} ({succescriterium.niveau})</span>
 											<h3>{succescriterium.titel}</h3>
@@ -165,7 +164,6 @@
 											type="checkbox"
 											checked={checkedSuccescriteria.find((e) => e.id === succescriterium.id)}
 										/>
-									</label>
 								</summary>
 								<!-- tekuitleg voor succescriterium -->
 


### PR DESCRIPTION
## What does this change?

Resolves issue #82 

Removes the label element inside the summary element on the criteria page.
The label caused the button on:click to be activated when clicking on the label and not on the button itself.

## How to review
Click outside the button somewhere in the summary to see if the button is activated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- De weergave van de vertaalknop in de checklist is aangepast, waardoor de interface overzichtelijker en consistent wordt gepresenteerd. De functionaliteit van de vertaaloptie blijft ongewijzigd.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->