### PR TITLE
feat: added a url couner for the loader next to the logs

### DIFF
--- a/src/lib/components/addForm.svelte
+++ b/src/lib/components/addForm.svelte
@@ -17,6 +17,8 @@
 
 	let sending = false;
 	let logs = [];
+	let urlCount = 0;
+	let urlTotal = 0;
 
 	let title;
 	let action;
@@ -84,6 +86,8 @@
 		sending = true;
 
 		logs = [];
+		urlCount = 0;
+		urlTotal = 0;
 
 		// handle form submission
 		const formData = new FormData(event.target);
@@ -122,7 +126,11 @@
 
 			for (const part of parts) {
 				if (!part.startsWith('data:')) continue;
-				const { status, type, error } = JSON.parse(part.replace(/^data:\s*/, ''));
+				const { status, type, error, count, total } = JSON.parse(part.replace(/^data:\s*/, ''));
+				if (count && total){
+					urlCount = count;
+					urlTotal = total;
+				}
 				if (error) {
 					logs = [...logs, { status: error, type: 'error' }];
 				} else {
@@ -392,7 +400,7 @@
 			<div class="tip-message" aria-label="tip message">
 				<p><span>{nameValue}</span> wordt verwerkt, sluit de pagina niet.</p>
 			</div>
-			<Loader itemArray={logs} />
+			<Loader itemArray={logs} urlCount={urlCount} urlTotal={urlTotal} />
 		{/if}
 	</section>
 </dialog>

--- a/src/lib/components/loader.svelte
+++ b/src/lib/components/loader.svelte
@@ -2,6 +2,8 @@
 	import { afterUpdate } from 'svelte';
 
 	export let itemArray = [];
+	export let urlCount;
+	export let urlTotal;
 
 	let logCount = 0;
 	let logList;
@@ -19,12 +21,19 @@
 </script>
 
 <details class="loader-container" aria-hidden="true" open>
-	<summary>Logs ({logCount})</summary>
+	<summary>
+		<p>Logs ({logCount})</p>
+		{#if urlCount && urlTotal}
+			<p><span class="loader"></span>Urls ({urlCount}/{urlTotal})</p>
+		{:else}
+			<p><span class="loader"></span>Aantal urls ophalen...</p>
+		{/if}
+	</summary>
 	<ul class="log-list" role="log" aria-live="polite" bind:this={logList}>
 		{#each itemArray as item}
 			<li class="log-item {item.type}">
 				{#if item.type === 'loading'}
-					<span class="loader" />
+					<span class="loader"></span>
 				{:else}
 					<img src="/icons/{item.type}.svg" alt={item.type} width="16" height="16" />
 				{/if}
@@ -40,6 +49,13 @@
 		border-radius: 0.25rem;
 		margin-top: 1rem;
 		color: var(--c-white);
+	}
+
+	summary {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
 	}
 
 	.log-list {

--- a/src/lib/utils/sitemap.js
+++ b/src/lib/utils/sitemap.js
@@ -107,7 +107,7 @@ export async function processUrls(urls, slug, sendUpdate) {
 		const link = urls[i];
 		const path = new URL(link).pathname;
 		let urlSlug = (slug + path).replace(/\//g, '-');
-		await sendUpdate({ status: `Verwerk URL ${i + 1}/${urls.length}`, type: 'done' });
+		await sendUpdate({ status: `Verwerk URL ${i + 1}/${urls.length}`, type: 'done', count: i + 1, total: urls.length });
 		await delay(250);
 
 		try {


### PR DESCRIPTION
## What does this change?

Resolves issue #130 

The sitemap utility now sends an update with a count en total object, the form handler in addForm will check if an update exists with these objects and then store them inside 2 variables which will be given as parameters with the loader component.
Inside the loader component these 2 variables will be loaded next to the logs counter.

## How Has This Been Tested?

- [ ] [User test]()
- [ ] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images

![image](https://github.com/user-attachments/assets/b439341e-4c76-42c1-9c43-3bda0955e7c1)
![image](https://github.com/user-attachments/assets/55baeec5-e367-4537-b880-a70b241f6e67)

## How to review

When fetching the sitemap of a partner check if the correct amount of urls is shown and if the counter updates correctly.
