### PR TITLE
Revise team schedule and sprint point target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,12 @@ Dankjewel voor je interesse in bijdragen aan dit project! Deze richtlijnen zorge
 ## Team afspraken
 - Houd je aan de afspraken/code conventies gemaakt in de contributing.md
 - We organiseren dagelijks een stand ups.
-- Rick werkt maandag, woensdag, vrijdag mee aan het project.
+- Rick werkt woensdag, donderdag, vrijdag mee aan het project.
 - Alle branches worden gemerged naar de dev-branch
 - Documentatie van de Sprint Reviews word genoteerd in issues
 - We gebruiken 1 taal in het project.
 - Aan het einde van elke sprint een retrospect (retromat).
+- We streven naar 60 punten per sprint
 
 ---
 


### PR DESCRIPTION
Updated team availability for Rick and added sprint goal.

## What does this change?
Kleine update

Resolves issue #155 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

No image available

## How to review
Hoeft niet we hebben het net besproken.

## Summary by Sourcery

Werkdagen van het team en sprintdoelen in de richtlijnen voor bijdragen bijgewerkt.

Verbeteringen:
- Rick's gedocumenteerde werkdagen in de sectie teamafspraken aangepast.
- Een sprintpuntdoel toegevoegd aan de teamafspraken in de richtlijnen voor bijdragen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documented team working days and sprint goals in the contributing guidelines.

Enhancements:
- Adjust Rick's documented working days in the team agreements section.
- Add a sprint point target to the team agreements in the contributing guidelines.

</details>