### PR TITLE
Fix/pagespagination

### DIFF
--- a/src/lib/components/checklist.svelte
+++ b/src/lib/components/checklist.svelte
@@ -26,9 +26,9 @@
 
 	let simpleTranslation = $state(true);
 
-	const checkedSuccescriteria = toolboardData.url.checks[0]
+	const checkedSuccescriteria = $derived(toolboardData.url.checks[0]
 		? toolboardData.url.checks[0].succescriteria
-		: [];
+		: []);
 
 	function scrollToTop(event) {
 		const mainElement = document.getElementById('main');

--- a/src/lib/components/checklist.svelte
+++ b/src/lib/components/checklist.svelte
@@ -26,9 +26,9 @@
 
 	let simpleTranslation = $state(true);
 
-	const checkedSuccescriteria = $derived(toolboardData.url.checks[0]
-		? toolboardData.url.checks[0].succescriteria
-		: []);
+	const checkedSuccescriteria = $derived(
+		toolboardData.url.checks[0] ? toolboardData.url.checks[0].succescriteria : []
+	);
 
 	function scrollToTop(event) {
 		const mainElement = document.getElementById('main');

--- a/src/lib/components/pages.svelte
+++ b/src/lib/components/pages.svelte
@@ -2,7 +2,7 @@
 	let { amount, perPage, currentPage } = $props();
 
 	// calculate the number of pages
-	let pageCount = $derived(Math.ceil(amount / perPage - 1));
+	let pageCount = $derived(Math.ceil(amount / perPage));
 
 	// calculate the skip values for the pageNumbers buttons
 	function getPages() {

--- a/src/lib/queries/partner.js
+++ b/src/lib/queries/partner.js
@@ -17,6 +17,11 @@ export default function getQueryPartner(gql, first = 20, skip = 0) {
 					}
 				}
 			}
+			websitesConnection {
+				aggregate {
+					count
+				}
+			}
 			principes {
 				titel
 				richtlijnen {

--- a/src/lib/queries/website.js
+++ b/src/lib/queries/website.js
@@ -16,7 +16,7 @@ export default function getQueryWebsite(gql, slug, first = 20, skip = 0) {
 						}
 					}
 				}
-				totalUrls
+				
 			}
 			principes {
 				titel
@@ -27,6 +27,11 @@ export default function getQueryWebsite(gql, slug, first = 20, skip = 0) {
 					}
 				}
 			}
+			urlsConnection(where: { website: { slug: "${slug}" } }) {    
+    			aggregate {
+      				count
+    			}
+  			}
 		}
 	`;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,12 +6,11 @@
 	import Search from '$lib/components/search.svelte';
 	import AddForm from '$lib/components/addForm.svelte';
 	import Pages from '$lib/components/pages.svelte';
-
 	let { data, form } = $props();
 
 	let skip = $derived(data.skip);
 	const first = $derived(data.first); 
-	let totalUrls = $derived(data.websitesData.urlsConnection.aggregate.count);
+	let totalUrls = $derived(Object.keys(data.websites.websites).length);
 	const currentPage = $derived(skip / first + 1);
 	let showRegistrationSuccess = $derived(data.showRegistrationSuccess);
 	let heading = { titel: 'Partners overzicht' };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
 
 	let skip = $derived(data.skip);
 	const first = $derived(data.first); 
-	let totalUrls = $derived(Object.keys(data.websites.websites).length);
+	let totalUrls = $derived(data.websites.websitesConnection.aggregate.count);
 	const currentPage = $derived(skip / first + 1);
 	let showRegistrationSuccess = $derived(data.showRegistrationSuccess);
 	let heading = { titel: 'Partners overzicht' };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
 	let { data, form } = $props();
 
 	let skip = $derived(data.skip);
-	const first = $derived(data.first); 
+	const first = $derived(data.first);
 	let totalUrls = $derived(data.websites.websitesConnection.aggregate.count);
 	const currentPage = $derived(skip / first + 1);
 	let showRegistrationSuccess = $derived(data.showRegistrationSuccess);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,8 +10,8 @@
 	let { data, form } = $props();
 
 	let skip = $derived(data.skip);
-	const first = $derived(data.first);
-	let totalUrls = $derived(data.websites.totalUrls);
+	const first = $derived(data.first); 
+	let totalUrls = $derived(data.websitesData.urlsConnection.aggregate.count);
 	const currentPage = $derived(skip / first + 1);
 	let showRegistrationSuccess = $derived(data.showRegistrationSuccess);
 	let heading = { titel: 'Partners overzicht' };

--- a/src/routes/[websiteUID]/+page.svelte
+++ b/src/routes/[websiteUID]/+page.svelte
@@ -10,7 +10,7 @@
 
 	let skip = $derived(data.skip);
 	const first = $derived(data.first);
-	let totalUrls = $derived(data.websites.website.totalUrls);
+	let totalUrls = $derived(data.websitesData.urlsConnection.aggregate.count);
 	const currentPage = $derived(skip / first + 1);
 
 	let heading = $derived({

--- a/src/routes/[websiteUID]/+page.svelte
+++ b/src/routes/[websiteUID]/+page.svelte
@@ -10,9 +10,8 @@
 
 	let skip = $derived(data.skip);
 	const first = $derived(data.first);
-	let totalUrls = $derived(data.websitesData.urlsConnection.aggregate.count);
+	let totalUrls = $derived(data.websites.urlsConnection.aggregate.count);
 	const currentPage = $derived(skip / first + 1);
-
 	let heading = $derived({
 		titel: data.websites.website.titel,
 		homepage: data.websites.website.homepage

--- a/src/routes/[websiteUID]/[urlUID]/+page.server.js
+++ b/src/routes/[websiteUID]/[urlUID]/+page.server.js
@@ -1,6 +1,6 @@
 import { gql } from 'graphql-request';
 import { hygraph } from '$lib/utils/hygraph.js';
-import { redirect } from '@sveltejs/kit';
+import { redirect, error } from '@sveltejs/kit';
 import getQueryUrl from '$lib/queries/url';
 import getQueryPrincipes from '$lib/queries/principes';
 import getQueryNiveaus from '$lib/queries/niveaus';
@@ -27,7 +27,7 @@ export const load = async ({ params, locals }) => {
 			urlData,
 			niveauData
 		};
-	throw (
+	throw error (
 		(404,
 		{
 			message: 'Not found'

--- a/src/routes/[websiteUID]/[urlUID]/+page.server.js
+++ b/src/routes/[websiteUID]/[urlUID]/+page.server.js
@@ -27,10 +27,7 @@ export const load = async ({ params, locals }) => {
 			urlData,
 			niveauData
 		};
-	throw error (
-		(404,
-		{
-			message: 'Not found'
-		})
-	);
+	throw error(404, {
+		message: 'Not found'
+	});
 };


### PR DESCRIPTION
## What does this change?

Replaces existing usage of the totalURLs DB row with a new aggregated amount of urls.
Totalurls for src/routes/+page.svelte is now calculated, previously this was always undefined.
Reverts change to pagecount calculation.

Resolves issue #188 

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()



## How to review


On the dev livesite, 
navigate to pagetest, witness that there are no pagination options visible.

On this branch.
navigate to pagetest, witness that there navigation options visible

## Summary by Sourcery

Paginering aanpassen om gebruik te maken van geaggregeerde URL-tellingen en de berekening van het aantal pagina’s te corrigeren.

Bugfixes:
- Zichtbaarheid van paginering op de paginatestweergave herstellen door het totale aantal URL’s voor de hoofdpagina correct te berekenen.
- De geaggregeerde URL-telling gebruiken voor websitedetailpagina’s zodat de paginering het werkelijke aantal URL’s weerspiegelt.
- De berekening van het aantal pagina’s corrigeren zodat het totale aantal pagina’s niet te laag wordt ingeschat.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust pagination to use aggregated URL counts and correct page count calculation.

Bug Fixes:
- Fix pagination visibility on the pagetest view by correctly computing total URLs for the main page.
- Use the aggregated URL count for website detail pages to ensure pagination reflects the actual number of URLs.
- Correct the page count calculation so the total number of pages is not undercounted.

</details>