### PR TITLE
Feature/fix expecting type 'string' for variable 'id' voorkomt bij oude sessies #199

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+    "compilerOptions": { //These checks will only occur if you use @ts-check
+    "strict": true,         
+    "noImplicitAny": true   
+  }
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "./.svelte-kit/tsconfig.json",
-    "compilerOptions": { //These checks will only occur if you use @ts-check
-    "strict": true,         
-    "noImplicitAny": true   
-  }
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		//These checks will only occur if you use @ts-check
+		"strict": true,
+		"noImplicitAny": true
+	}
 }

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -5,22 +5,22 @@ import {
 } from '$lib/server/session';
 
 export async function handle({ event, resolve }) {
-	event.locals.gebruiker = null;
-	event.locals.sessie = null;
+	event.locals.user = null;
+	event.locals.session = null;
 
 	const token = event.cookies.get('session') ?? null;
 	if (token === null) {
 		return resolve(event);
 	}
 
-	const { sessie, gebruiker } = await validateSessionToken(token);
-	if (sessie !== null) {
-		setSessionTokenCookie(event, token, sessie.houdbaarTot);
+	const { session, user } = await validateSessionToken(token);
+	if (session !== null) {
+		setSessionTokenCookie(event, token, session.houdbaarTot);
 	} else {
 		deleteSessionTokenCookie(event);
 	}
 
-	event.locals.sessie = sessie;
-	event.locals.gebruiker = gebruiker;
+	event.locals.session = session;
+	event.locals.user = user;
 	return resolve(event);
 }

--- a/src/lib/queries/addSession.js
+++ b/src/lib/queries/addSession.js
@@ -1,0 +1,15 @@
+export default function getQueryAddSession(gql) {
+	return gql`
+		mutation CreateSessie($userId: ID!, $expiresAt: Date!, $sessionId: String!) {
+			createSessie(
+				data: {
+					sessieId: $sessionId
+					gebruikerId: { connect: { id: $userId } }
+					houdbaarTot: $expiresAt
+				}
+			) {
+				id
+			}
+		}
+	`;
+}

--- a/src/lib/queries/deleteSession.js
+++ b/src/lib/queries/deleteSession.js
@@ -1,0 +1,9 @@
+export default function getQueryDeleteSession(gql) {
+	return gql`
+		mutation DeleteSessie($sessionId: String!) {
+			deleteSessie(where: { sessieId: $sessionId }) {
+				id
+			}
+		}
+	`;
+}

--- a/src/lib/queries/session.js
+++ b/src/lib/queries/session.js
@@ -1,0 +1,17 @@
+export default function getQuerySession(gql) {
+	return gql`
+		query GetSessie($sessionId: String!) {
+			sessie(where: { sessieId: $sessionId }) {
+				id
+				sessieId
+				houdbaarTot
+				gebruikerId {
+					id
+					email
+					gebruikersnaam
+					isEmailGeverifieerd
+				}
+			}
+		}
+	`;
+}

--- a/src/lib/queries/updateSession.js
+++ b/src/lib/queries/updateSession.js
@@ -1,0 +1,9 @@
+export default function getQueryUpdateSession(gql) {
+	return gql`
+		mutation UpdateSessie($sessionId: String!, $expiresAt: Date!) {
+			updateSessie(where: { sessieId: $sessionId }, data: { houdbaarTot: $expiresAt }) {
+				id
+			}
+		}
+	`;
+}

--- a/src/lib/server/email-verification.js
+++ b/src/lib/server/email-verification.js
@@ -133,14 +133,14 @@ export function deleteEmailVerificationRequestCookie(event) {
 
 // Deze functie haalt het huidige e-mailverificatieverzoek van de gebruiker op via het ID uit de cookie
 export async function getUserEmailVerificationRequestFromRequest(event) {
-	if (event.locals.gebruiker === null) {
+	if (event.locals.user === null) {
 		return null;
 	}
 	const id = event.cookies.get('email_verification') ?? null;
 	if (id === null) {
 		return null;
 	}
-	const request = getUserEmailVerificationRequest(event.locals.gebruiker.id, id);
+	const request = getUserEmailVerificationRequest(event.locals.user.id, id);
 	if (request === null) {
 		deleteEmailVerificationRequestCookie(event);
 	}

--- a/src/lib/server/session.js
+++ b/src/lib/server/session.js
@@ -4,6 +4,10 @@ import { hygraph } from '$lib/utils/hygraph.js';
 import { gql } from 'graphql-request';
 import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from '@oslojs/encoding';
 import { sha256 } from '@oslojs/crypto/sha2';
+import getQuerySession from '$lib/queries/session';
+import getQueryDeleteSession from '$lib/queries/deleteSession';
+import getQueryUpdateSession from '$lib/queries/updateSession';
+import getQueryAddSession from '$lib/queries/addSession';
 
 // Type definitions
 /**
@@ -31,23 +35,7 @@ import { sha256 } from '@oslojs/crypto/sha2';
  */
 export async function validateSessionToken(token) {
 	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
-	const sessionQuery = gql`
-		query GetSessie($sessionId: String!) {
-			sessie(where: { sessieId: $sessionId }) {
-				id
-				sessieId
-				houdbaarTot
-				gebruikerId {
-					id
-					email
-					gebruikersnaam
-					isEmailGeverifieerd
-				}
-			}
-		}
-	`;
-	const sessionData = await hygraph.request(sessionQuery, { sessionId });
-	const row = sessionData.sessie;
+	const { sessie: row } = await hygraph.request(getQuerySession(gql), { sessionId });
 
 	if (!row) {
 		return { session: null, user: null };
@@ -98,14 +86,7 @@ export async function validateSessionToken(token) {
  */
 export async function invalidateSession(session) {
 	// Delete session mutation
-	const deleteMutation = gql`
-		mutation DeleteSessie($id: String!) {
-			deleteSessie(where: { sessieId: $id }) {
-				id
-			}
-		}
-	`;
-	await hygraph.request(deleteMutation, { id: session.id });
+	await hygraph.request(getQueryDeleteSession(gql), { sessionId: session.id });
 	return { session: null, user: null };
 }
 
@@ -121,15 +102,8 @@ export async function invalidateSession(session) {
 export async function refreshSession(session) {
 	session.houdbaarTot = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 	// Update session mutation
-	const updateMutation = gql`
-		mutation UpdateSessie($id: String!, $expiresAt: Date!) {
-			updateSessie(where: { sessieId: $id }, data: { houdbaarTot: $expiresAt }) {
-				id
-			}
-		}
-	`;
-	await hygraph.request(updateMutation, {
-		id: session.id,
+	await hygraph.request(getQueryUpdateSession(gql), {
+		sessionId: session.id,
 		expiresAt: session.houdbaarTot
 	});
 	return session;
@@ -192,20 +166,7 @@ export async function createSession(token, gebruikerId) {
 		gebruikerId,
 		houdbaarTot: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30)
 	};
-	const createMutation = gql`
-		mutation CreateSessie($userId: ID!, $expiresAt: Date!, $sessionId: String!) {
-			createSessie(
-				data: {
-					sessieId: $sessionId
-					gebruikerId: { connect: { id: $userId } }
-					houdbaarTot: $expiresAt
-				}
-			) {
-				id
-			}
-		}
-	`;
-	await hygraph.request(createMutation, {
+	await hygraph.request(getQueryAddSession(gql), {
 		userId: session.gebruikerId,
 		expiresAt: session.houdbaarTot.toISOString(),
 		sessionId: session.id

--- a/src/lib/server/session.js
+++ b/src/lib/server/session.js
@@ -84,7 +84,7 @@ export async function validateSessionToken(token) {
  * @param {Session} session - The session to delete.
  * @returns {Promise<{ session: null, user: null }>} An object with nulled session and user values.
  */
-export async function invalidateSession(session) {
+async function invalidateSession(session) {
 	// Delete session mutation
 	await hygraph.request(getQueryDeleteSession(gql), { sessionId: session.id });
 	return { session: null, user: null };
@@ -99,7 +99,7 @@ export async function invalidateSession(session) {
  * @param { Session } session - The session object to be refreshed
  * @returns {Promise<Session>} A session with a refreshed lifetime
  */
-export async function refreshSession(session) {
+async function refreshSession(session) {
 	session.houdbaarTot = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 	// Update session mutation
 	await hygraph.request(getQueryUpdateSession(gql), {

--- a/src/lib/server/session.js
+++ b/src/lib/server/session.js
@@ -156,17 +156,12 @@ export function setSessionTokenCookie(event, token, houdbaarTot) {
 /**
  * Deletes a session token cookie on the given event.
  *
+ * @author Maksim Hofker
  * @author Bjarne Zeeman
  * @param {import('@sveltejs/kit').RequestEvent} event - The request event containing cookies.
  */
 export function deleteSessionTokenCookie(event) {
-	event.cookies.set('session', '', {
-		httpOnly: true,
-		path: '/',
-		secure: import.meta.env.PROD,
-		sameSite: 'lax',
-		maxAge: 0
-	});
+	event.cookies.delete('session', { path: '/' });
 }
 
 /**

--- a/src/lib/server/session.js
+++ b/src/lib/server/session.js
@@ -14,7 +14,7 @@ import getQueryAddSession from '$lib/queries/addSession';
  * @typedef {Object} Session
  * @property {string|null} id
  * @property {string|null} gebruikerId
- * @property {Date} houdbaarTot
+ * @property {Date} expiresAt
  */
 /**
  * @typedef {Object} User
@@ -47,7 +47,7 @@ export async function validateSessionToken(token) {
 	let session = {
 		id: row.sessieId,
 		gebruikerId: row.gebruikerId.id,
-		houdbaarTot: new Date(row.houdbaarTot)
+		expiresAt: new Date(row.expiresAt)
 	};
 
 	/**
@@ -64,9 +64,9 @@ export async function validateSessionToken(token) {
 	}
 
 	//Invalidate session if outdated Else Refresh session if old
-	if (Date.now() >= session.houdbaarTot.getTime()) {
+	if (Date.now() >= session.expiresAt.getTime()) {
 		({ session, user } = await invalidateSession(session));
-	} else if (Date.now() >= session.houdbaarTot.getTime() - 1000 * 60 * 60 * 24 * 15) {
+	} else if (Date.now() >= session.expiresAt.getTime() - 1000 * 60 * 60 * 24 * 15) {
 		session = await refreshSession(session);
 	}
 	return { session, user };
@@ -92,7 +92,6 @@ async function invalidateSession(session) {
 
 /**
  * Refreshes a session
- *
  * @async
  * @author Maksim Hofker
  * @author Bjarne Zeeman
@@ -100,11 +99,11 @@ async function invalidateSession(session) {
  * @returns {Promise<Session>} A session with a refreshed lifetime
  */
 async function refreshSession(session) {
-	session.houdbaarTot = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
+	session.expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 	// Update session mutation
 	await hygraph.request(getQueryUpdateSession(gql), {
 		sessionId: session.id,
-		expiresAt: session.houdbaarTot
+		expiresAt: session.expiresAt
 	});
 	return session;
 }
@@ -115,15 +114,15 @@ async function refreshSession(session) {
  * @author Bjarne Zeeman
  * @param {import('@sveltejs/kit').RequestEvent} event - The request event containing cookies.
  * @param {string} token - The session token to store in the cookie.
- * @param {Date} houdbaarTot - The expiration date of the cookie.
+ * @param {Date} expiresAt - The expiration date of the cookie.
  */
-export function setSessionTokenCookie(event, token, houdbaarTot) {
+export function setSessionTokenCookie(event, token, expiresAt) {
 	event.cookies.set('session', token, {
 		httpOnly: true,
 		path: '/',
 		secure: import.meta.env.PROD,
 		sameSite: 'lax',
-		expires: houdbaarTot
+		expires: expiresAt
 	});
 }
 
@@ -164,11 +163,11 @@ export async function createSession(token, gebruikerId) {
 	const session = {
 		id: sessionId,
 		gebruikerId,
-		houdbaarTot: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30)
+		expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30)
 	};
 	await hygraph.request(getQueryAddSession(gql), {
 		userId: session.gebruikerId,
-		expiresAt: session.houdbaarTot.toISOString(),
+		expiresAt: session.expiresAt.toISOString(),
 		sessionId: session.id
 	});
 	return session;

--- a/src/lib/server/session.js
+++ b/src/lib/server/session.js
@@ -1,12 +1,37 @@
+//@ts-check
 import * as crypto from 'crypto';
 import { hygraph } from '$lib/utils/hygraph.js';
 import { gql } from 'graphql-request';
 import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from '@oslojs/encoding';
 import { sha256 } from '@oslojs/crypto/sha2';
 
+// Type definitions
+/**
+ * @typedef {Object} Session
+ * @property {string|null} id
+ * @property {string|null} gebruikerId
+ * @property {Date} houdbaarTot
+ */
+/**
+ * @typedef {Object} User
+ * @property {string} id
+ * @property {string} email
+ * @property {string} gebruikersnaam
+ * @property {boolean} isEmailGeverifieerd
+ */
+
+// Code
+/**
+ * Validates a Session token
+ * @author Maksim Hofker
+ * @author Bjarne Zeeman
+ * @async
+ * @param {String} token The session token to be validated
+ * @returns {Promise<{ session: Session | null , user: User  | null }>}
+ */
 export async function validateSessionToken(token) {
 	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
-	const sessieQuery = gql`
+	const sessionQuery = gql`
 		query GetSessie($sessionId: String!) {
 			sessie(where: { sessieId: $sessionId }) {
 				id
@@ -21,22 +46,28 @@ export async function validateSessionToken(token) {
 			}
 		}
 	`;
-	const sessieData = await hygraph.request(sessieQuery, { sessionId });
-	const row = sessieData.sessie;
+	const sessionData = await hygraph.request(sessionQuery, { sessionId });
+	const row = sessionData.sessie;
 
 	if (!row) {
-		return { sessie: null, gebruiker: null };
+		return { session: null, user: null };
 	}
 
-	const sessie = {
+	/**
+	 * @type {Session}
+	 */
+	let session = {
 		id: row.sessieId,
 		gebruikerId: row.gebruikerId.id,
 		houdbaarTot: new Date(row.houdbaarTot)
 	};
 
-	let gebruiker = null;
+	/**
+	 * @type {null | User}
+	 */
+	let user = null;
 	if (row.gebruikerId) {
-		gebruiker = {
+		user = {
 			id: row.gebruikerId.id,
 			email: row.gebruikerId.email,
 			gebruikersnaam: row.gebruikerId.gebruikersnaam,
@@ -44,45 +75,66 @@ export async function validateSessionToken(token) {
 		};
 	}
 
-	if (Date.now() >= sessie.houdbaarTot.getTime()) {
-		// Delete session mutation
-		const deleteMutation = gql`
-			mutation DeleteSessie($id: ID!) {
-				deleteSessie(where: { id: $id }) {
-					id
-				}
-			}
-		`;
-		await hygraph.request(deleteMutation, { id: sessie.id });
-		return { sessie: null, gebruiker: null };
+	//Invalidate session if outdated
+	if (Date.now() >= session.houdbaarTot.getTime()) {
+		({ session, user } = await invalidateSession(session));
 	}
-	if (Date.now() >= sessie.houdbaarTot.getTime() - 1000 * 60 * 60 * 24 * 15) {
-		sessie.houdbaarTot = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
-		// Update session mutation
-		const updateMutation = gql`
-			mutation UpdateSessie($id: ID!, $expiresAt: Date!) {
-				updateSessie(where: { sessieId: $id }, data: { houdbaarTot: $expiresAt }) {
-					id
-				}
-			}
-		`;
-		await hygraph.request(updateMutation, {
-			id: sessie.sessieId,
-			expiresAt: Math.floor(sessie.houdbaarTot.getTime() / 1000)
-		});
+	//Refresh session if old
+	if (Date.now() >= session.houdbaarTot.getTime() - 1000 * 60 * 60 * 24 * 15) {
+		session = await refreshSession(session);
 	}
-	return { sessie, gebruiker };
+	return { session, user };
 }
 
-export async function invalidateSession(sessionId) {
+/**
+ * Deletes the given session from Hygraph.
+ *
+ * Note:
+ * This function does NOT clear the session cookie.
+ *
+ * @async
+ * @author Maksim Hofker
+ * @author Bjarne Zeeman
+ * @param {Session} session - The session to delete.
+ * @returns {Promise<{ session: null, user: null }>} An object with nulled session and user values.
+ */
+export async function invalidateSession(session) {
+	// Delete session mutation
 	const deleteMutation = gql`
-		mutation DeleteSessie($id: String!) {
+		mutation DeleteSessie($id: ID!) {
 			deleteSessie(where: { sessieId: $id }) {
 				id
 			}
 		}
 	`;
-	await hygraph.request(deleteMutation, { id: sessionId });
+	await hygraph.request(deleteMutation, { id: session.id });
+	return { session: null, user: null };
+}
+
+/**
+ * Refreshes a session
+ *
+ * @async
+ * @author Maksim Hofker
+ * @author Bjarne Zeeman
+ * @param { Session } session - The session object to be refreshed
+ * @returns {Promise<Session>} A session with a refreshed lifetime
+ */
+export async function refreshSession(session) {
+	session.houdbaarTot = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
+	// Update session mutation
+	const updateMutation = gql`
+		mutation UpdateSessie($id: String!, $expiresAt: Date!) {
+			updateSessie(where: { sessieId: $id }, data: { houdbaarTot: $expiresAt }) {
+				id
+			}
+		}
+	`;
+	await hygraph.request(updateMutation, {
+		id: session.id,
+		expiresAt: new Date(Math.floor(session.houdbaarTot.getTime() / 1000))
+	});
+	return session;
 }
 
 export function setSessionTokenCookie(event, token, houdbaarTot) {

--- a/src/lib/server/session.js
+++ b/src/lib/server/session.js
@@ -54,7 +54,7 @@ export async function validateSessionToken(token) {
 	}
 
 	/**
-	 * @type {Session}
+	 * @type {null | Session}
 	 */
 	let session = {
 		id: row.sessieId,
@@ -75,12 +75,10 @@ export async function validateSessionToken(token) {
 		};
 	}
 
-	//Invalidate session if outdated
+	//Invalidate session if outdated Else Refresh session if old
 	if (Date.now() >= session.houdbaarTot.getTime()) {
 		({ session, user } = await invalidateSession(session));
-	}
-	//Refresh session if old
-	if (Date.now() >= session.houdbaarTot.getTime() - 1000 * 60 * 60 * 24 * 15) {
+	} else if (Date.now() >= session.houdbaarTot.getTime() - 1000 * 60 * 60 * 24 * 15) {
 		session = await refreshSession(session);
 	}
 	return { session, user };
@@ -137,6 +135,14 @@ export async function refreshSession(session) {
 	return session;
 }
 
+/**
+ * Sets a session token cookie on the given event.
+ *
+ * @author Bjarne Zeeman
+ * @param {import('@sveltejs/kit').RequestEvent} event - The request event containing cookies.
+ * @param {string} token - The session token to store in the cookie.
+ * @param {Date} houdbaarTot - The expiration date of the cookie.
+ */
 export function setSessionTokenCookie(event, token, houdbaarTot) {
 	event.cookies.set('session', token, {
 		httpOnly: true,
@@ -147,6 +153,12 @@ export function setSessionTokenCookie(event, token, houdbaarTot) {
 	});
 }
 
+/**
+ * Deletes a session token cookie on the given event.
+ *
+ * @author Bjarne Zeeman
+ * @param {import('@sveltejs/kit').RequestEvent} event - The request event containing cookies.
+ */
 export function deleteSessionTokenCookie(event) {
 	event.cookies.set('session', '', {
 		httpOnly: true,
@@ -157,12 +169,27 @@ export function deleteSessionTokenCookie(event) {
 	});
 }
 
+/**
+ * Generates a session token
+ *
+ * @author Bjarne Zeeman
+ * @returns {String} session token
+ */
 export function generateSessionToken() {
 	const tokenBytes = crypto.randomBytes(20);
 	const token = encodeBase32LowerCaseNoPadding(tokenBytes).toLowerCase();
 	return token;
 }
 
+/**
+ * Creates a new Session
+ *
+ * @author Bjarne Zeeman
+ * @async
+ * @param {String} token
+ * @param {string} gebruikerId
+ * @returns {Promise<Session>}
+ */
 export async function createSession(token, gebruikerId) {
 	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
 	const session = {

--- a/src/lib/server/session.js
+++ b/src/lib/server/session.js
@@ -99,7 +99,7 @@ export async function validateSessionToken(token) {
 export async function invalidateSession(session) {
 	// Delete session mutation
 	const deleteMutation = gql`
-		mutation DeleteSessie($id: ID!) {
+		mutation DeleteSessie($id: String!) {
 			deleteSessie(where: { sessieId: $id }) {
 				id
 			}
@@ -130,7 +130,7 @@ export async function refreshSession(session) {
 	`;
 	await hygraph.request(updateMutation, {
 		id: session.id,
-		expiresAt: new Date(Math.floor(session.houdbaarTot.getTime() / 1000))
+		expiresAt: session.houdbaarTot
 	});
 	return session;
 }

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -11,7 +11,7 @@ export async function load({ params, locals }) {
 	const queryPrincipes = getQueryPrincipes(gql);
 
 	return {
-		gebruiker: locals.gebruiker,
+		gebruiker: locals.user,
 		partnersData: await hygraph.request(queryPartner),
 		websitesData: await hygraph.request(queryWebsite),
 		principesData: await hygraph.request(queryPrincipes)

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -5,10 +5,10 @@ import getQueryPartner from '$lib/queries/partner';
 
 export async function load(event) {
 	const { url, locals, cookies } = event;
-	if (locals.sessie === null || locals.gebruiker === null) {
+	if (locals.session === null || locals.user === null) {
 		throw redirect(302, '/login');
 	}
-	if (!locals.gebruiker.isEmailGeverifieerd) {
+	if (!locals.user.isEmailGeverifieerd) {
 		throw redirect(302, '/verify-email');
 	}
 	const first = 20;

--- a/src/routes/[websiteUID]/+page.server.js
+++ b/src/routes/[websiteUID]/+page.server.js
@@ -10,10 +10,10 @@ function delay(ms) {
 export async function load(event) {
 	const { params, url, locals } = event;
 	const { websiteUID } = params;
-	if (locals.sessie === null || locals.gebruiker === null) {
+	if (locals.session=== null || locals.user === null) {
 		throw redirect(302, '/login');
 	}
-	if (!locals.gebruiker.isEmailGeverifieerd) {
+	if (!locals.user.isEmailGeverifieerd) {
 		throw redirect(302, '/verify-email');
 	}
 	const first = 20;

--- a/src/routes/[websiteUID]/+page.server.js
+++ b/src/routes/[websiteUID]/+page.server.js
@@ -10,7 +10,7 @@ function delay(ms) {
 export async function load(event) {
 	const { params, url, locals } = event;
 	const { websiteUID } = params;
-	if (locals.session=== null || locals.user === null) {
+	if (locals.session === null || locals.user === null) {
 		throw redirect(302, '/login');
 	}
 	if (!locals.user.isEmailGeverifieerd) {

--- a/src/routes/[websiteUID]/[urlUID]/+page.server.js
+++ b/src/routes/[websiteUID]/[urlUID]/+page.server.js
@@ -7,10 +7,10 @@ import getQueryNiveaus from '$lib/queries/niveaus';
 
 export const load = async ({ params, locals }) => {
 	const { websiteUID, urlUID } = params;
-	if (!locals?.sessie || !locals?.gebruiker) {
+	if (!locals?.session || !locals?.user) {
 		throw redirect(302, '/login');
 	}
-	if (!locals.gebruiker.isEmailGeverifieerd) {
+	if (!locals.user.isEmailGeverifieerd) {
 		throw redirect(302, '/verify-email');
 	}
 

--- a/src/routes/[websiteUID]/[urlUID]/[principeUID]/+page.server.js
+++ b/src/routes/[websiteUID]/[urlUID]/[principeUID]/+page.server.js
@@ -10,10 +10,10 @@ import getQueryNiveaus from '$lib/queries/niveaus.js';
 
 export const load = async ({ params, locals }) => {
 	const { websiteUID, urlUID, principeUID } = params;
-	if (!locals?.sessie || !locals?.gebruiker) {
+	if (!locals?.session || !locals?.user) {
 		throw redirect(302, '/login');
 	}
-	if (!locals.gebruiker.isEmailGeverifieerd) {
+	if (!locals.user.isEmailGeverifieerd) {
 		throw redirect(302, '/verify-email');
 	}
 	const queryUrl = getQueryUrl(gql, urlUID);

--- a/src/routes/[websiteUID]/addUrl/+page.server.js
+++ b/src/routes/[websiteUID]/addUrl/+page.server.js
@@ -7,10 +7,10 @@ import createEmptyCheck from '$lib/queries/addEmptyCheck';
 
 export async function load({ params, locals }) {
 	const { websiteUID } = params;
-	if (!locals?.sessie || !locals?.gebruiker) {
+	if (!locals?.session || !locals?.user) {
 		throw redirect(302, '/login');
 	}
-	if (!locals.gebruiker.isEmailGeverifieerd) {
+	if (!locals.user.isEmailGeverifieerd) {
 		throw redirect(302, '/verify-email');
 	}
 	let query = getQueryWebsite(gql, websiteUID);

--- a/src/routes/addPartner/+page.server.js
+++ b/src/routes/addPartner/+page.server.js
@@ -4,10 +4,10 @@ import { redirect } from '@sveltejs/kit';
 import getQueryAddPartner from '$lib/queries/addPartner';
 
 export async function load({ locals }) {
-	if (!locals?.sessie || !locals?.gebruiker) {
+	if (!locals?.session || !locals?.user) {
 		throw redirect(302, '/login');
 	}
-	if (!locals.gebruiker.isEmailGeverifieerd) {
+	if (!locals.user.isEmailGeverifieerd) {
 		throw redirect(302, '/verify-email');
 	}
 	return {};

--- a/src/routes/login/+page.server.js
+++ b/src/routes/login/+page.server.js
@@ -6,8 +6,8 @@ import { createSession, generateSessionToken, setSessionTokenCookie } from '$lib
 
 export function load(event) {
 	const { locals } = event;
-	if (locals.sessie !== null && locals.gebruiker !== null) {
-		if (!locals.gebruiker.isEmailGeverifieerd) {
+	if (locals.session !== null && locals.user !== null) {
+		if (!locals.user.isEmailGeverifieerd) {
 			throw redirect(302, '/verify-email');
 		}
 		throw redirect(302, '/');

--- a/src/routes/login/+page.server.js
+++ b/src/routes/login/+page.server.js
@@ -56,7 +56,7 @@ export const actions = {
 
 		const sessionToken = generateSessionToken();
 		const session = await createSession(sessionToken, user.id);
-		setSessionTokenCookie(event, sessionToken, session.houdbaarTot);
+		setSessionTokenCookie(event, sessionToken, session.expiresAt);
 
 		if (!user.isEmailGeverifieerd) {
 			throw redirect(302, '/verify-email');

--- a/src/routes/register/+page.server.js
+++ b/src/routes/register/+page.server.js
@@ -92,7 +92,7 @@ export const actions = {
 		setEmailVerificationRequestCookie(event, emailVerificationRequest);
 		const sessionToken = generateSessionToken();
 		const session = await createSession(sessionToken, user.id);
-		setSessionTokenCookie(event, sessionToken, session.houdbaarTot);
+		setSessionTokenCookie(event, sessionToken, session.expiresAt);
 
 		throw redirect(302, '/verify-email');
 	}

--- a/src/routes/register/+page.server.js
+++ b/src/routes/register/+page.server.js
@@ -11,8 +11,8 @@ import {
 
 export function load(event) {
 	const { locals } = event;
-	if (locals.sessie !== null && locals.gebruiker !== null) {
-		if (!locals.gebruiker.isEmailGeverifieerd) {
+	if (locals.session !== null && locals.user !== null) {
+		if (!locals.user.isEmailGeverifieerd) {
 			throw redirect(302, '/verify-email');
 		}
 		throw redirect(302, '/');

--- a/src/routes/verify-email/+page.server.js
+++ b/src/routes/verify-email/+page.server.js
@@ -11,19 +11,19 @@ import { setUserEmailAsVerified } from '$lib/server/user';
 
 export async function load(event) {
 	// Controleer of de gebruiker is ingelogd
-	if (event.locals.gebruiker === null) {
+	if (event.locals.user === null) {
 		throw redirect(302, '/login');
 	}
 
 	// Controleer of de gebruiker zijn e-mail al heeft geverifieerd
-	if (event.locals.gebruiker.isEmailGeverifieerd) {
+	if (event.locals.user.isEmailGeverifieerd) {
 		throw redirect(302, '/');
 	}
 
 	// Controleer of er een lopend e-mailverificatieverzoek is
 	let verificationRequest = await getUserEmailVerificationRequestFromRequest(event);
 	if (verificationRequest === null || Date.now() >= verificationRequest.expiresAt.getTime()) {
-		verificationRequest = await createEmailVerificationRequest(event.locals.gebruiker.id);
+		verificationRequest = await createEmailVerificationRequest(event.locals.user.id);
 
 		// Stuur een nieuwe verificatie-e-mail als het verzoek nieuw of verlopen is
 		sendVerificationEmail(verificationRequest.email, verificationRequest.code);
@@ -48,7 +48,7 @@ function delay(ms) {
 // Deze functie handelt de verificatie van de door de gebruiker ingevoerde code af
 async function verifyCode(event) {
 	// Controleer of de gebruiker is ingelogd
-	if (event.locals.sessie === null || event.locals.gebruiker === null) {
+	if (event.locals.session === null || event.locals.user === null) {
 		return fail(401, {
 			verify: {
 				message: 'Niet geauthenticeerd'
@@ -86,7 +86,7 @@ async function verifyCode(event) {
 
 	// Controleer of de code correct is en niet verlopen
 	if (Date.now() >= verificationRequest.expiresAt.getTime()) {
-		verificationRequest = await createEmailVerificationRequest(event.locals.gebruiker.id);
+		verificationRequest = await createEmailVerificationRequest(event.locals.user.id);
 		sendVerificationEmail(verificationRequest.email, verificationRequest.code);
 		return {
 			verify: {
@@ -105,8 +105,8 @@ async function verifyCode(event) {
 	}
 
 	// Als de code correct is, markeer het e-mailadres als geverifieerd en verwijder het verzoek en de cookie
-	await deleteUserEmailVerificationRequest(event.locals.gebruiker.id);
-	await setUserEmailAsVerified(event.locals.gebruiker.id, verificationRequest.email);
+	await deleteUserEmailVerificationRequest(event.locals.user.id);
+	await setUserEmailAsVerified(event.locals.user.id, verificationRequest.email);
 	deleteEmailVerificationRequestCookie(event);
 
 	await delay(500);
@@ -122,7 +122,7 @@ async function verifyCode(event) {
 
 async function resendEmail(event) {
 	// Controleer of de gebruiker is ingelogd
-	if (event.locals.sessie === null || event.locals.gebruiker === null) {
+	if (event.locals.session === null || event.locals.user === null) {
 		return fail(401, {
 			resend: {
 				message: 'Niet geauthenticeerd'
@@ -133,16 +133,16 @@ async function resendEmail(event) {
 	// Controleer of de gebruiker zijn e-mail al heeft geverifieerd
 	let verificationRequest = await getUserEmailVerificationRequestFromRequest(event);
 	if (verificationRequest === null) {
-		if (event.locals.gebruiker.isEmailGeverifieerd) {
+		if (event.locals.user.isEmailGeverifieerd) {
 			return fail(403, {
 				resend: {
 					message: 'Niet toegestaan'
 				}
 			});
 		}
-		verificationRequest = await createEmailVerificationRequest(event.locals.gebruiker.id);
+		verificationRequest = await createEmailVerificationRequest(event.locals.user.id);
 	} else {
-		verificationRequest = await createEmailVerificationRequest(event.locals.gebruiker.id);
+		verificationRequest = await createEmailVerificationRequest(event.locals.user.id);
 	}
 
 	// Stuur een nieuwe verificatie-e-mail en zet de cookie

--- a/tests/hooks.server.test.js
+++ b/tests/hooks.server.test.js
@@ -24,8 +24,8 @@ describe('hooks.server.js', () => {
 		await handle({ event, resolve });
 
 		// Assert
-		expect(event.locals.gebruiker).toBeNull();
-		expect(event.locals.sessie).toBeNull();
+		expect(event.locals.user).toBeNull();
+		expect(event.locals.session).toBeNull();
 		expect(resolve).toHaveBeenCalled();
 	});
 
@@ -33,8 +33,8 @@ describe('hooks.server.js', () => {
 		// Arrange
 		event.cookies.get.mockReturnValue('token');
 		vi.spyOn(sessionModule, 'validateSessionToken').mockResolvedValue({
-			sessie: { houdbaarTot: new Date(Date.now() + 10000) },
-			gebruiker: { id: '1' }
+			session: { houdbaarTot: new Date(Date.now() + 10000) },
+			user: { id: '1' }
 		});
 		const setCookie = vi.spyOn(sessionModule, 'setSessionTokenCookie').mockImplementation(() => {});
 
@@ -42,8 +42,8 @@ describe('hooks.server.js', () => {
 		await handle({ event, resolve });
 
 		// Assert
-		expect(event.locals.sessie).toBeTruthy();
-		expect(event.locals.gebruiker).toBeTruthy();
+		expect(event.locals.session).toBeTruthy();
+		expect(event.locals.user).toBeTruthy();
 		expect(setCookie).toHaveBeenCalled();
 		expect(resolve).toHaveBeenCalled();
 	});
@@ -52,8 +52,8 @@ describe('hooks.server.js', () => {
 		// Arrange
 		event.cookies.get.mockReturnValue('token');
 		vi.spyOn(sessionModule, 'validateSessionToken').mockResolvedValue({
-			sessie: null,
-			gebruiker: null
+			session: null,
+			user: null
 		});
 		const deleteCookie = vi
 			.spyOn(sessionModule, 'deleteSessionTokenCookie')
@@ -63,8 +63,8 @@ describe('hooks.server.js', () => {
 		await handle({ event, resolve });
 
 		// Assert
-		expect(event.locals.sessie).toBeNull();
-		expect(event.locals.gebruiker).toBeNull();
+		expect(event.locals.session).toBeNull();
+		expect(event.locals.user).toBeNull();
 		expect(deleteCookie).toHaveBeenCalled();
 		expect(resolve).toHaveBeenCalled();
 	});

--- a/tests/hooks.server.test.js
+++ b/tests/hooks.server.test.js
@@ -33,7 +33,7 @@ describe('hooks.server.js', () => {
 		// Arrange
 		event.cookies.get.mockReturnValue('token');
 		vi.spyOn(sessionModule, 'validateSessionToken').mockResolvedValue({
-			session: { houdbaarTot: new Date(Date.now() + 10000) },
+			session: { expiresAt: new Date(Date.now() + 10000) },
 			user: { id: '1' }
 		});
 		const setCookie = vi.spyOn(sessionModule, 'setSessionTokenCookie').mockImplementation(() => {});

--- a/tests/lib/server/session.test.js
+++ b/tests/lib/server/session.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, assert, mockImplementation } from 'vitest';
+import * as sessionModule from '$lib/server/session';
+import { hygraph } from '$lib/utils/hygraph';
+
+describe('session.js', () => {
+	let event, resolve;
+	beforeEach(() => {
+		event = {
+			cookies: {
+				get: vi.fn()
+			}
+		};
+		resolve = vi.fn((e) => e);
+		vi.resetAllMocks();
+	});
+
+	const now = Date.now();
+	const fakeSession = {
+		id: '1',
+		sessieId: 'abc123',
+		houdbaarTot: new Date(now + 10 * 24 * 60 * 60 * 1000), //10 days of lifetime left.
+		gebruikerId: {
+			id: 'u1',
+			email: 'test@example.com',
+			gebruikersnaam: 'tester',
+			isEmailGeverifieerd: true
+		}
+	};
+
+	it('Should refresh a old session', async () => {
+		// Arrange
+		//Mocking hygraph for isolation
+		vi.spyOn(hygraph, 'request').mockImplementation(async (query, vars) => {
+			if (query.includes('DeleteSessie')) return {};
+			if (query.includes('UpdateSessie')) return {};
+			return { sessie: fakeSession };
+		});
+		vi.setSystemTime(now); //Freezes time for better predictability
+		const expectedDate = new Date(now + 1000 * 60 * 60 * 24 * 30);
+
+		// Act
+		const { session, user } = await sessionModule.validateSessionToken('notimportant');
+		// Assert
+		console.log(session);
+		expect(session.houdbaarTot).toStrictEqual(expectedDate);
+	});
+});

--- a/tests/lib/server/session.test.js
+++ b/tests/lib/server/session.test.js
@@ -41,7 +41,6 @@ describe('session.js', () => {
 		// Act
 		const { session, user } = await sessionModule.validateSessionToken('notimportant');
 		// Assert
-		console.log(session);
 		expect(session.houdbaarTot).toStrictEqual(expectedDate);
 	});
 });

--- a/tests/lib/server/session.test.js
+++ b/tests/lib/server/session.test.js
@@ -18,7 +18,7 @@ describe('session.js', () => {
 	const fakeSession = {
 		id: '1',
 		sessieId: 'abc123',
-		houdbaarTot: new Date(now + 10 * 24 * 60 * 60 * 1000), //10 days of lifetime left.
+		expiresAt: new Date(now + 10 * 24 * 60 * 60 * 1000), //10 days of lifetime left.
 		gebruikerId: {
 			id: 'u1',
 			email: 'test@example.com',
@@ -41,6 +41,6 @@ describe('session.js', () => {
 		// Act
 		const { session, user } = await sessionModule.validateSessionToken('notimportant');
 		// Assert
-		expect(session.houdbaarTot).toStrictEqual(expectedDate);
+		expect(session.expiresAt).toStrictEqual(expectedDate);
 	});
 });

--- a/tests/routes/login/page.server.test.js
+++ b/tests/routes/login/page.server.test.js
@@ -76,7 +76,7 @@ describe('src/routes/login/+page.server.js', () => {
 		vi.spyOn(passwordModule, 'verifyPasswordHash').mockResolvedValue(true);
 		vi.spyOn(sessionModule, 'generateSessionToken').mockReturnValue('token');
 		vi.spyOn(sessionModule, 'createSession').mockResolvedValue({
-			houdbaarTot: new Date(Date.now() + 10000)
+			expiresAt: new Date(Date.now() + 10000)
 		});
 		const setSessionTokenCookie = vi
 			.spyOn(sessionModule, 'setSessionTokenCookie')

--- a/tests/routes/register/page.server.test.js
+++ b/tests/routes/register/page.server.test.js
@@ -61,7 +61,7 @@ describe('src/routes/register/+page.server.js', () => {
 
 	it('redirects if user is already logged in', () => {
 		const locals = {
-			sessie: { id: '567ads567ads', houdbaarTot: new Date() },
+			sessie: { id: '567ads567ads', expiresAt: new Date() },
 			gebruiker: { id: 1, email: 'test@vervoerregio.nl', gebruikersnaam: 'John' }
 		};
 		const callLoad = () => load({ locals });
@@ -237,7 +237,7 @@ describe('src/routes/register/+page.server.js', () => {
 		passwordModule.hashPassword.mockResolvedValue('hashed-password');
 		userModule.createUser.mockResolvedValue({ id: 'user-id', email: 'test@vervoerregio.nl' });
 		sessionModule.generateSessionToken.mockReturnValue('token');
-		sessionModule.createSession.mockResolvedValue({ houdbaarTot: 'future-date' });
+		sessionModule.createSession.mockResolvedValue({ expiresAt: 'future-date' });
 
 		try {
 			await actions.register(event);


### PR DESCRIPTION
## What does this change?

Resolves issue #199

- De UpdateSession en DeleteSession queries worden nu correct aangeroepen
- Session.js refactored, Heeft nu typedefs voor static type checking.
- Queries zijn in aparte bestanden gezet
- Test implementeerd om voor deze bug te checken

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()
## How to review

1. Create or alter a session that has less than 15 days left in Hygraph


2. On prod, Log in and witness the error code 500 page.
3. Check the session, notice that it has not changed.

5. On this branch, Log in. You should not see a error code.
6. Check the session, You should notice that the expiration date should now be extended to 30 days from now.

The delete logic was also broken, to check it. ensure the session's houdbaarTot is in the past and repeat the previous paths