### PR TITLE
Fix/152 bug verplaats de logica uit logout die de sessie verwijderd uit hygraph naar srclibserversessionjs om de logica goed op te splitsen

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,8 +1,4 @@
-import {
-	validateSessionToken,
-	setSessionTokenCookie,
-	deleteSessionTokenCookie
-} from '$lib/server/session';
+import { sessionService } from '$lib/server/session';
 
 export async function handle({ event, resolve }) {
 	event.locals.user = null;
@@ -13,11 +9,11 @@ export async function handle({ event, resolve }) {
 		return resolve(event);
 	}
 
-	const { session, user } = await validateSessionToken(token);
+	const { session, user } = await sessionService.validateSessionToken(token);
 	if (session !== null) {
-		setSessionTokenCookie(event, token, session.expiresAt);
+		sessionService.setSessionTokenCookie(event, token, session.expiresAt);
 	} else {
-		deleteSessionTokenCookie(event);
+		await sessionService.DeleteSession(event);
 	}
 
 	event.locals.session = session;

--- a/src/lib/server/repositories/sessionRepository.js
+++ b/src/lib/server/repositories/sessionRepository.js
@@ -11,18 +11,11 @@ import getQuerySession, {
 import { DIRECTUS_URL, VITE_DIRECTUS_KEY } from '$env/static/private';
 
 /** @typedef {import('$lib/types').Session} Session */
+/** @typedef {import('$lib/types').User} User */
 /**
- * @typedef {{
- *   id?: string;
- *   session_id?: string;
- *   expires_at?: string;
- *   user_id?: {
- *     id: string;
- *     email: string;
- *     username: string;
- *     is_email_verified?: boolean;
- *   };
- * }} SessionRow
+ */
+/**
+ * @typedef {{ session: Session; user: User }} SessionWithUser
  */
 
 /**
@@ -35,7 +28,7 @@ export class SessionRepository extends BaseRepository {
 	 * Load session row by token hash (hex string stored from the session cookie).
 	 *
 	 * @param {string} sessionId Hashed session id as used in GraphQL variables (`sessionId`).
-	 * @returns {Promise<SessionRow | null>}
+	 * @returns {Promise<SessionWithUser | null>}
 	 */
 	async getSessionByTokenHash(sessionId) {
 		try {
@@ -45,7 +38,36 @@ export class SessionRepository extends BaseRepository {
 				variables: { sessionId }
 			});
 			const row = this.firstOrNull(sessionResult);
-			return row ?? null;
+			if (!row) {
+				return null;
+			}
+
+			const mapped = {
+				session: {
+					id: row.session_id ?? row.id ?? '',
+					userId: row.user_id?.id ?? '',
+					expiresAt: row.expires_at ? new Date(row.expires_at) : new Date('')
+				},
+				user: {
+					id: row.user_id?.id ?? '',
+					email: row.user_id?.email ?? '',
+					username: row.user_id?.username ?? '',
+					isEmailVerified: row.user_id?.is_email_verified ?? false
+				}
+			};
+
+			const requiredFields = [
+				mapped.session.id,
+				mapped.session.userId,
+				mapped.user.id,
+				mapped.user.email,
+				mapped.user.username
+			];
+			if (!requiredFields.every(Boolean) || Number.isNaN(mapped.session.expiresAt.getTime())) {
+				return null;
+			}
+
+			return mapped;
 		} catch (error) {
 			console.error('sessionRepository.getSessionByTokenHash failed', error);
 			return null;
@@ -94,7 +116,7 @@ export class SessionRepository extends BaseRepository {
 	 * Insert a session via Directus REST (server-side key). Returns a minimal `Session` for cookies.
 	 *
 	 * @param {{ sessionId: string; userId: string; expiresAt: Date }} input `sessionId` is the opaque token string (not the hash).
-	 * @returns {Promise<Session | null>}
+	 * @returns {Promise<Session>}
 	 */
 	async createSessionRecord({ sessionId, userId, expiresAt }) {
 		try {
@@ -112,13 +134,13 @@ export class SessionRepository extends BaseRepository {
 			});
 
 			if (!response.ok) {
-				return null;
+				throw new Error('createSessionRecord failed: response not ok');
 			}
 
 			return { id: sessionId, userId, expiresAt };
 		} catch (error) {
 			console.error('sessionRepository.createSessionRecord failed', error);
-			return null;
+			throw error;
 		}
 	}
 }

--- a/src/lib/server/session.js
+++ b/src/lib/server/session.js
@@ -109,7 +109,7 @@ export class SessionService {
 	 */
 	async DeleteSession(event) {
 		const token = event.cookies.get('session');
-		if (!token) { //
+		if (!token) {
 			event.cookies.delete('session', { path: '/' });
 			return;
 		}

--- a/src/lib/server/session.js
+++ b/src/lib/server/session.js
@@ -11,149 +11,143 @@ import { sessionRepository } from '$lib/server/index.js';
  * @typedef {import('@sveltejs/kit').RequestEvent} RequestEvent
  */
 
-// Code
 /**
- * Validates a Session token
- * @author Maksim Hofker
- * @author Bjarne Zeeman
- * @async
- * @param {String} token The session token to be validated
- * @returns {Promise<{ session: Session | null , user: User  | null }>}
+ * This class is responsible for all session related operations
  */
-export async function validateSessionToken(token) {
-	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
-	const sessionRow = await sessionRepository.getSessionByTokenHash(sessionId);
+export class SessionService {
+	/**
+	 * Validates a Session token
+	 * @async
+	 * @param {String} token The session token to be validated
+	 * @returns {Promise<{ session: Session | null , user: User  | null }>}
+	 */
+	async validateSessionToken(token) {
+		const sessionData = await sessionRepository.getSessionByTokenHash(
+			encodeHexLowerCase(sha256(new TextEncoder().encode(token)))
+		);
+		if (!sessionData) {
+			return { session: null, user: null };
+		}
 
-	if (
-		!sessionRow ||
-		!(sessionRow.session_id || sessionRow.id) ||
-		!sessionRow.user_id?.id ||
-		!sessionRow.expires_at
-	) {
+		let { session, user } = sessionData;
+
+		// Invalidate session if outdated Else refresh if old.
+		if (Date.now() >= session.expiresAt.getTime()) {
+			return this.invalidateSession(session);
+		} else if (Date.now() >= session.expiresAt.getTime() - 1000 * 60 * 60 * 24 * 15) {
+			session = await this.refreshSession(session);
+		}
+		return { session, user };
+	}
+
+	/**
+	 * Deletes the given session from Hygraph.
+	 *
+	 * Note:
+	 * This function does NOT clear the session cookie.
+	 *
+	 * @async
+	 * @param {Session} session - The session to delete.
+	 * @returns {Promise<{ session: null, user: null }>} An object with nulled session and user values.
+	 */
+	async invalidateSession(session) {
+		await sessionRepository.deleteSessionById(session.id);
 		return { session: null, user: null };
 	}
 
-	const sessionIdFromRow = sessionRow.session_id ?? sessionRow.id;
-	const userIdFromRow = sessionRow.user_id.id;
-	const expiresAtFromRow = sessionRow.expires_at;
-
-	/** @type {Session | null} */
-	let session = {
-		id: sessionIdFromRow,
-		userId: userIdFromRow,
-		expiresAt: new Date(expiresAtFromRow)
-	};
+	/**
+	 * Refreshes a session
+	 * @async
+	 * @param { Session } session - The session object to be refreshed
+	 * @returns {Promise<Session>} A session with a refreshed lifetime
+	 */
+	async refreshSession(session) {
+		session.expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
+		await sessionRepository.updateSessionExpiry({
+			sessionId: session.id,
+			expiresAt: session.expiresAt
+		});
+		return session;
+	}
 
 	/**
-	 * @type {null | User}
+	 * Sets a session token cookie on the given event.
+	 *
+	 * @author Bjarne Zeeman
+	 * @param {RequestEvent} event - The request event containing cookies.
+	 * @param {string} token - The session token to store in the cookie.
+	 * @param {Date} expiresAt - The expiration date of the cookie.
 	 */
-	let user = null;
-	const userNode = sessionRow.user_id;
-	if (userNode) {
-		user = {
-			id: userNode.id,
-			email: userNode.email,
-			username: userNode.username,
-			isEmailVerified: userNode.is_email_verified ?? false
-		};
+	setSessionTokenCookie(event, token, expiresAt) {
+		event.cookies.set('session', token, {
+			httpOnly: true,
+			path: '/',
+			secure: import.meta.env.PROD,
+			sameSite: 'lax',
+			expires: expiresAt
+		});
 	}
 
-	//Invalidate session if outdated Else Refresh session if old
-	if (Date.now() >= session.expiresAt.getTime()) {
-		({ session, user } = await invalidateSession(session));
-	} else if (Date.now() >= session.expiresAt.getTime() - 1000 * 60 * 60 * 24 * 15) {
-		session = await refreshSession(session);
+	/**
+	 * Creates a session and sets the session cookie.
+	 *
+	 * @param {RequestEvent} event - The request event containing cookies.
+	 * @param {string} userId - The user id for the new session.
+	 * @returns {Promise<Session>}
+	 */
+	async createAndSetSession(event, userId) {
+		const sessionToken = this.#generateSessionToken();
+		const session = await this.#createSession(sessionToken, userId);
+		this.setSessionTokenCookie(event, sessionToken, session.expiresAt);
+		return session;
 	}
-	return { session, user };
+
+	/**
+	 * Deletes a session from DB and clears the local session cookie.
+	 *
+	 * @param {RequestEvent} event - The request event containing cookies.
+	 */
+	async DeleteSession(event) {
+		const token = event.cookies.get('session');
+		if (!token) { //
+			event.cookies.delete('session', { path: '/' });
+			return;
+		}
+
+		const sessionRow = await sessionRepository.getSessionByTokenHash(
+			encodeHexLowerCase(sha256(new TextEncoder().encode(token)))
+		);
+		if (sessionRow?.session) {
+			await this.invalidateSession(sessionRow.session);
+		}
+
+		event.cookies.delete('session', { path: '/' });
+	}
+
+	/**
+	 * Generates a session token
+	 *
+	 * @returns {String} session token
+	 */
+	#generateSessionToken() {
+		const tokenBytes = crypto.randomBytes(20);
+		const token = encodeBase32LowerCaseNoPadding(tokenBytes).toLowerCase();
+		return token;
+	}
+
+	/**
+	 * Creates a new Session
+	 *
+	 * @async
+	 * @param {String} token
+	 * @param {string} userId
+	 * @returns {Promise<Session>}
+	 */
+	async #createSession(token, userId) {
+		const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+		const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
+		return sessionRepository.createSessionRecord({ sessionId, userId, expiresAt });
+	}
 }
 
-/**
- * Deletes the given session from Hygraph.
- *
- * Note:
- * This function does NOT clear the session cookie.
- *
- * @async
- * @author Maksim Hofker
- * @author Bjarne Zeeman
- * @param {Session} session - The session to delete.
- * @returns {Promise<{ session: null, user: null }>} An object with nulled session and user values.
- */
-async function invalidateSession(session) {
-	await sessionRepository.deleteSessionById(session.id);
-	return { session: null, user: null };
-}
-
-/**
- * Refreshes a session
- * @async
- * @author Maksim Hofker
- * @author Bjarne Zeeman
- * @param { Session } session - The session object to be refreshed
- * @returns {Promise<Session>} A session with a refreshed lifetime
- */
-async function refreshSession(session) {
-	session.expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
-	await sessionRepository.updateSessionExpiry({
-		sessionId: session.id,
-		expiresAt: session.expiresAt
-	});
-	return session;
-}
-
-/**
- * Sets a session token cookie on the given event.
- *
- * @author Bjarne Zeeman
- * @param {RequestEvent} event - The request event containing cookies.
- * @param {string} token - The session token to store in the cookie.
- * @param {Date} expiresAt - The expiration date of the cookie.
- */
-export function setSessionTokenCookie(event, token, expiresAt) {
-	event.cookies.set('session', token, {
-		httpOnly: true,
-		path: '/',
-		secure: import.meta.env.PROD,
-		sameSite: 'lax',
-		expires: expiresAt
-	});
-}
-
-/**
- * Deletes a session token cookie on the given event.
- *
- * @author Maksim Hofker
- * @author Bjarne Zeeman
- * @param {RequestEvent} event - The request event containing cookies.
- */
-export function deleteSessionTokenCookie(event) {
-	event.cookies.delete('session', { path: '/' });
-}
-
-/**
- * Generates a session token
- *
- * @author Bjarne Zeeman
- * @returns {String} session token
- */
-export function generateSessionToken() {
-	const tokenBytes = crypto.randomBytes(20);
-	const token = encodeBase32LowerCaseNoPadding(tokenBytes).toLowerCase();
-	return token;
-}
-
-/**
- * Creates a new Session
- *
- * @author Bjarne Zeeman
- * @async
- * @param {String} token
- * @param {string} userId
- * @returns {Promise<Session>}
- */
-export async function createSession(token, userId) {
-	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
-	const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
-	const session = await sessionRepository.createSessionRecord({ sessionId, userId, expiresAt });
-	return session;
-}
+export const sessionService = new SessionService();

--- a/src/routes/login/+page.server.js
+++ b/src/routes/login/+page.server.js
@@ -2,7 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import { verifyEmailInput } from '$lib/server/email';
 import { getUserFromEmail, getUserPasswordHash } from '$lib/server/user';
 import { verifyPasswordHash } from '$lib/server/password';
-import { createSession, generateSessionToken, setSessionTokenCookie } from '$lib/server/session';
+import { sessionService } from '$lib/server/session';
 
 export function load(event) {
 	const { locals } = event;
@@ -54,9 +54,7 @@ export const actions = {
 			});
 		}
 
-		const sessionToken = generateSessionToken();
-		const session = await createSession(sessionToken, user.id);
-		setSessionTokenCookie(event, sessionToken, session.expiresAt);
+		await sessionService.createAndSetSession(event, user.id);
 
 		if (!user.isEmailVerified) {
 			throw redirect(302, '/verify-email');

--- a/src/routes/logout/+server.js
+++ b/src/routes/logout/+server.js
@@ -1,14 +1,6 @@
-import { deleteSessionTokenCookie } from '$lib/server/session.js';
-import { sessionRepository } from '$lib/server/index.js';
-import { sha256 } from '@oslojs/crypto/sha2';
-import { encodeHexLowerCase } from '@oslojs/encoding';
+import { sessionService } from '$lib/server/session.js';
 
 export async function POST({ cookies }) {
-	const sessionToken = cookies.get('session');
-	if (sessionToken) {
-		const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(sessionToken)));
-		await sessionRepository.deleteSessionById(sessionId);
-		deleteSessionTokenCookie({ cookies });
-	}
+	await sessionService.DeleteSession({ cookies });
 	return new Response(null, { status: 204 });
 }

--- a/src/routes/register/+page.server.js
+++ b/src/routes/register/+page.server.js
@@ -2,7 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import { checkEmailAvailability, verifyEmailInput, isValidEmailDomain } from '$lib/server/email';
 import { createUser, verifyUsernameInput, checkUsernameAvailability } from '$lib/server/user';
 import { verifyPasswordStrength, hashPassword } from '$lib/server/password';
-import { createSession, generateSessionToken, setSessionTokenCookie } from '$lib/server/session';
+import { sessionService } from '$lib/server/session';
 import {
 	createEmailVerificationRequest,
 	sendVerificationEmail,
@@ -90,9 +90,7 @@ export const actions = {
 		const emailVerificationRequest = await createEmailVerificationRequest(user.id);
 		sendVerificationEmail(emailVerificationRequest.email, emailVerificationRequest.code);
 		setEmailVerificationRequestCookie(event, emailVerificationRequest);
-		const sessionToken = generateSessionToken();
-		const session = await createSession(sessionToken, user.id);
-		setSessionTokenCookie(event, sessionToken, session.expiresAt);
+		await sessionService.createAndSetSession(event, user.id);
 
 		throw redirect(302, '/verify-email');
 	}

--- a/tests/hooks.server.test.js
+++ b/tests/hooks.server.test.js
@@ -32,11 +32,13 @@ describe('hooks.server.js', () => {
 	it('should set session and user if token is valid', async () => {
 		// Arrange
 		event.cookies.get.mockReturnValue('token');
-		vi.spyOn(sessionModule, 'validateSessionToken').mockResolvedValue({
+		vi.spyOn(sessionModule.sessionService, 'validateSessionToken').mockResolvedValue({
 			session: { expiresAt: new Date(Date.now() + 10000) },
 			user: { id: '1' }
 		});
-		const setCookie = vi.spyOn(sessionModule, 'setSessionTokenCookie').mockImplementation(() => {});
+		const setCookie = vi
+			.spyOn(sessionModule.sessionService, 'setSessionTokenCookie')
+			.mockImplementation(() => {});
 
 		// Act
 		await handle({ event, resolve });
@@ -51,12 +53,12 @@ describe('hooks.server.js', () => {
 	it('should delete session cookie if token is invalid', async () => {
 		// Arrange
 		event.cookies.get.mockReturnValue('token');
-		vi.spyOn(sessionModule, 'validateSessionToken').mockResolvedValue({
+		vi.spyOn(sessionModule.sessionService, 'validateSessionToken').mockResolvedValue({
 			session: null,
 			user: null
 		});
 		const deleteCookie = vi
-			.spyOn(sessionModule, 'deleteSessionTokenCookie')
+			.spyOn(sessionModule.sessionService, 'DeleteSession')
 			.mockImplementation(() => {});
 
 		// Act

--- a/tests/lib/server/repositories/sessionRepository.test.js
+++ b/tests/lib/server/repositories/sessionRepository.test.js
@@ -22,18 +22,30 @@ describe('SessionRepository', () => {
 	});
 
 	describe('getSessionByTokenHash', () => {
-		it('returns first session row from GraphQL response', async () => {
+		it('returns mapped session and user from GraphQL response', async () => {
 			const row = {
 				id: 's1',
 				session_id: 'opaque',
 				expires_at: new Date().toISOString(),
-				user_id: { id: 'u1', email: 'a@b.c', username: 'u' }
+				user_id: { id: 'u1', email: 'a@b.c', username: 'u', is_email_verified: true }
 			};
 			client.request.mockResolvedValue({ session: [row] });
 
 			const result = await repository.getSessionByTokenHash('hashed');
 
-			expect(result).toEqual(row);
+			expect(result).toEqual({
+				session: {
+					id: 'opaque',
+					userId: 'u1',
+					expiresAt: new Date(row.expires_at)
+				},
+				user: {
+					id: 'u1',
+					email: 'a@b.c',
+					username: 'u',
+					isEmailVerified: true
+				}
+			});
 			expect(client.request).toHaveBeenCalledWith(
 				expect.objectContaining({
 					variables: { sessionId: 'hashed' }
@@ -154,30 +166,30 @@ describe('SessionRepository', () => {
 			vi.unstubAllGlobals();
 		});
 
-		it('returns null when response is not ok', async () => {
+		it('throws when response is not ok', async () => {
 			vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
 
-			const result = await repository.createSessionRecord({
-				sessionId: 'a',
-				userId: 'b',
-				expiresAt: new Date()
-			});
-
-			expect(result).toBeNull();
+			await expect(
+				repository.createSessionRecord({
+					sessionId: 'a',
+					userId: 'b',
+					expiresAt: new Date()
+				})
+			).rejects.toThrow();
 			vi.unstubAllGlobals();
 		});
 
-		it('returns null when fetch throws', async () => {
+		it('throws when fetch throws', async () => {
 			const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 			vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
 
-			const result = await repository.createSessionRecord({
-				sessionId: 'a',
-				userId: 'b',
-				expiresAt: new Date()
-			});
-
-			expect(result).toBeNull();
+			await expect(
+				repository.createSessionRecord({
+					sessionId: 'a',
+					userId: 'b',
+					expiresAt: new Date()
+				})
+			).rejects.toThrow('offline');
 			spy.mockRestore();
 			vi.unstubAllGlobals();
 		});

--- a/tests/lib/server/session.test.js
+++ b/tests/lib/server/session.test.js
@@ -18,15 +18,17 @@ describe('session.js', () => {
 	});
 
 	const now = Date.now();
-	const fakeSessionRow = {
-		id: '1',
-		session_id: 'abc123',
-		expires_at: new Date(now + 10 * 24 * 60 * 60 * 1000).toISOString(), // 10 days of lifetime left
-		user_id: {
+	const fakeSessionData = {
+		session: {
+			id: 'abc123',
+			userId: 'u1',
+			expiresAt: new Date(now + 10 * 24 * 60 * 60 * 1000) // 10 days of lifetime left
+		},
+		user: {
 			id: 'u1',
 			email: 'test@example.com',
 			username: 'tester',
-			is_email_verified: true
+			isEmailVerified: true
 		}
 	};
 
@@ -35,13 +37,13 @@ describe('session.js', () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(now);
 
-		sessionRepository.getSessionByTokenHash.mockResolvedValue(fakeSessionRow);
+		sessionRepository.getSessionByTokenHash.mockResolvedValue(fakeSessionData);
 		sessionRepository.updateSessionExpiry.mockResolvedValue(undefined);
 
 		const expectedDate = new Date(now + 1000 * 60 * 60 * 24 * 30);
 
 		// Act
-		const { session } = await sessionModule.validateSessionToken('notimportant');
+		const { session } = await sessionModule.sessionService.validateSessionToken('notimportant');
 
 		// Assert
 		expect(session).not.toBeNull();

--- a/tests/routes/login/page.server.test.js
+++ b/tests/routes/login/page.server.test.js
@@ -74,13 +74,9 @@ describe('src/routes/login/+page.server.js', () => {
 		});
 		vi.spyOn(userModule, 'getUserPasswordHash').mockResolvedValue('hash');
 		vi.spyOn(passwordModule, 'verifyPasswordHash').mockResolvedValue(true);
-		vi.spyOn(sessionModule, 'generateSessionToken').mockReturnValue('token');
-		vi.spyOn(sessionModule, 'createSession').mockResolvedValue({
-			expiresAt: new Date(Date.now() + 10000)
-		});
-		const setSessionTokenCookie = vi
-			.spyOn(sessionModule, 'setSessionTokenCookie')
-			.mockImplementation(() => {});
+		const createAndSetSession = vi
+			.spyOn(sessionModule.sessionService, 'createAndSetSession')
+			.mockResolvedValue({ expiresAt: new Date(Date.now() + 10000) });
 
 		try {
 			await actions.signin(event);
@@ -90,6 +86,6 @@ describe('src/routes/login/+page.server.js', () => {
 			expect(e.location).toBe('/');
 		}
 
-		expect(setSessionTokenCookie).toHaveBeenCalled();
+		expect(createAndSetSession).toHaveBeenCalledWith(event, '1');
 	});
 });

--- a/tests/routes/logout/server.test.js
+++ b/tests/routes/logout/server.test.js
@@ -1,23 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '../../../src/routes/logout/+server.js';
 import * as sessionModule from '$lib/server/session.js';
-import { sessionRepository } from '$lib/server/index.js';
-import { sha256 } from '@oslojs/crypto/sha2';
-import { encodeHexLowerCase } from '@oslojs/encoding';
-
-vi.mock('$lib/server/index.js', () => ({
-	sessionRepository: {
-		deleteSessionById: vi.fn()
-	}
-}));
 vi.mock('$lib/server/session.js', () => ({
-	deleteSessionTokenCookie: vi.fn()
-}));
-vi.mock('@oslojs/crypto/sha2', () => ({
-	sha256: vi.fn((input) => new Uint8Array([1, 2, 3]))
-}));
-vi.mock('@oslojs/encoding', () => ({
-	encodeHexLowerCase: vi.fn(() => 'mockedSessionId')
+	sessionService: {
+		DeleteSession: vi.fn()
+	}
 }));
 
 describe('src/routes/logout/+server.js', () => {
@@ -33,17 +20,12 @@ describe('src/routes/logout/+server.js', () => {
 	it('should delete session and cookie if session token exists', async () => {
 		// Arrange
 		cookies.get.mockReturnValue('token');
-		sessionRepository.deleteSessionById.mockResolvedValue(undefined);
 
 		// Act
 		const response = await POST({ cookies });
 
 		// Assert
-		expect(cookies.get).toHaveBeenCalledWith('session');
-		expect(encodeHexLowerCase).toHaveBeenCalled();
-		expect(sha256).toHaveBeenCalled();
-		expect(sessionRepository.deleteSessionById).toHaveBeenCalledWith('mockedSessionId');
-		expect(sessionModule.deleteSessionTokenCookie).toHaveBeenCalledWith({ cookies });
+		expect(sessionModule.sessionService.DeleteSession).toHaveBeenCalledWith({ cookies });
 		expect(response.status).toBe(204);
 	});
 
@@ -55,8 +37,7 @@ describe('src/routes/logout/+server.js', () => {
 		const response = await POST({ cookies });
 
 		// Assert
-		expect(sessionRepository.deleteSessionById).not.toHaveBeenCalled();
-		expect(sessionModule.deleteSessionTokenCookie).not.toHaveBeenCalled();
+		expect(sessionModule.sessionService.DeleteSession).toHaveBeenCalledWith({ cookies });
 		expect(response.status).toBe(204);
 	});
 });

--- a/tests/routes/register/page.server.test.js
+++ b/tests/routes/register/page.server.test.js
@@ -40,9 +40,9 @@ vi.mock('$lib/server/password', () => ({
 	hashPassword: vi.fn()
 }));
 vi.mock('$lib/server/session', () => ({
-	createSession: vi.fn(),
-	generateSessionToken: vi.fn(),
-	setSessionTokenCookie: vi.fn()
+	sessionService: {
+		createAndSetSession: vi.fn()
+	}
 }));
 
 describe('src/routes/register/+page.server.js', () => {
@@ -236,8 +236,7 @@ describe('src/routes/register/+page.server.js', () => {
 		passwordModule.verifyPasswordStrength.mockResolvedValue({ valid: true });
 		passwordModule.hashPassword.mockResolvedValue('hashed-password');
 		userModule.createUser.mockResolvedValue({ id: 'user-id', email: 'test@vervoerregio.nl' });
-		sessionModule.generateSessionToken.mockReturnValue('token');
-		sessionModule.createSession.mockResolvedValue({ expiresAt: 'future-date' });
+		sessionModule.sessionService.createAndSetSession.mockResolvedValue({ expiresAt: 'future-date' });
 
 		try {
 			await actions.register(event);
@@ -256,8 +255,6 @@ describe('src/routes/register/+page.server.js', () => {
 			'John',
 			'hashed-password'
 		);
-		expect(sessionModule.generateSessionToken).toHaveBeenCalled();
-		expect(sessionModule.createSession).toHaveBeenCalledWith('token', 'user-id');
-		expect(sessionModule.setSessionTokenCookie).toHaveBeenCalledWith(event, 'token', 'future-date');
+		expect(sessionModule.sessionService.createAndSetSession).toHaveBeenCalledWith(event, 'user-id');
 	});
 });

--- a/tests/routes/register/page.server.test.js
+++ b/tests/routes/register/page.server.test.js
@@ -236,7 +236,9 @@ describe('src/routes/register/+page.server.js', () => {
 		passwordModule.verifyPasswordStrength.mockResolvedValue({ valid: true });
 		passwordModule.hashPassword.mockResolvedValue('hashed-password');
 		userModule.createUser.mockResolvedValue({ id: 'user-id', email: 'test@vervoerregio.nl' });
-		sessionModule.sessionService.createAndSetSession.mockResolvedValue({ expiresAt: 'future-date' });
+		sessionModule.sessionService.createAndSetSession.mockResolvedValue({
+			expiresAt: 'future-date'
+		});
 
 		try {
 			await actions.register(event);


### PR DESCRIPTION
## What does this change?

Resolves issue #152 

Moves logic into session.js
Encapsulated functions into a new sessionService class
Refactored sessionRepository to return mapped data or errors

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()
- [x] Integration tests

## Images

No visible changes


## How to review

The logout route's currently inaccessible, so here's a way to test for changes.

On dev, delete your session token and login
On this branch, delete your session token and login

