### PR TITLE
fix: removed dark from color scheme

### DIFF
--- a/static/global.css
+++ b/static/global.css
@@ -1,5 +1,5 @@
 :root {
-	color-scheme: light dark;
+	color-scheme: light;
 	--color-primary: #b9005f;
 	--color-primary-light: #f1ccdf;
 


### PR DESCRIPTION
## What does this change?

Fixes the issue where the application would switch to dark mode if the user's browser was set to dark mode, despite it no longer being supported

Resolves issue #254 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

1. Change browser to dark mode
2. Check if application is still in light mode like it is supposed to