### PR TITLE
fix: fixes regression in dialog component that displayed the wrong content for the audit dialog

### DIFF
--- a/src/lib/components/templates/dialog.svelte
+++ b/src/lib/components/templates/dialog.svelte
@@ -217,13 +217,11 @@
 							Weet je zeker dat je {isType === 'deleteUrl' ? formData.url : formData.name} wilt verwijderen?
 						</p>
 					</div>
-				{/if}
-
-				{#if isType === 'startAudit'}
-					<div class="form-delete-content" tabindex="0">
-						<Icon iconName="delete" />
+				{:else if isType === 'startAudit'}
+					<div class="form-audit-content" tabindex="0">
+						<Icon iconName="audit" />
 						<p>
-							Weet je zeker dat je {isType === 'deleteUrl' ? formData.url : formData.name} wilt verwijderen?
+							Weet je zeker dat je een audit wilt starten voor {formData.name}?
 						</p>
 					</div>
 				{/if}


### PR DESCRIPTION
## What does this change?

Reverts a regression that showed the contents for the delete dialog when pressing the audit button

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
