### PR TITLE
fix/remove totalurls references

### DIFF
--- a/src/lib/components/templates/subheader.svelte
+++ b/src/lib/components/templates/subheader.svelte
@@ -47,12 +47,7 @@
 	<div class="subheader-form">
 		<!-- this will be placed on a sidebar of the principles page -->
 		<div class="subheader-form-up-wrapper">
-			<NavButton
-				size="small"
-				variant="primary"
-				showIcon={true}
-				iconName="add"
-				onclick={onAdd}
+			<NavButton size="small" variant="primary" showIcon={true} iconName="add" onclick={onAdd}
 			></NavButton>
 			<Search effect="disabled" />
 		</div>

--- a/src/lib/server/queries/partner.js
+++ b/src/lib/server/queries/partner.js
@@ -141,19 +141,6 @@ export function getQueryUpdatePartner(name, slug, url, id) {
 	`;
 }
 
-export function getQueryUpdatePartnerUrls(slug, totalUrls) {
-	return `
-		mutation {
-			update_toolgankelijk_website_item(
-				id: "${slug}"
-				data: { totalUrls: ${totalUrls} }
-			) {
-				id
-			}
-		}
-	`;
-}
-
 export function getQueryDeletePartner(id) {
 	return `
 		mutation {

--- a/src/lib/server/repositories/partnerRepository.js
+++ b/src/lib/server/repositories/partnerRepository.js
@@ -10,7 +10,6 @@ import getQueryPartner, {
 	getQueryUrlsByPartnerId,
 	getQueryAddPartner,
 	getQueryUpdatePartner,
-	getQueryUpdatePartnerUrls,
 	getQueryDeletePartner
 } from '../queries/partner.js';
 
@@ -142,7 +141,7 @@ export class PartnerRepository extends BaseDirectusRepository {
 			const query = getQueryAddPartner(name, url, slug);
 			const raw = await this.client.query(query);
 			const row = raw.create_toolgankelijk_website_item ?? null;
-			if (!row) throw error;
+			if (!row) throw new Error(`Kon partner '${name}' niet aanmaken.`);
 			return {
 				id: row.id,
 				title: row.title,
@@ -165,7 +164,8 @@ export class PartnerRepository extends BaseDirectusRepository {
 			const query = getQueryUpdatePartner(name, slug, url, id);
 			const raw = await this.client.query(query);
 			const row = raw.update_toolgankelijk_website_item ?? null;
-			if (!row) return null;
+			console.log(row);
+			if (!row) throw new Error(`Kon partner met ID '${id}' niet bijwerken.`);
 			return {
 				id: row.id,
 				title: name,
@@ -174,27 +174,6 @@ export class PartnerRepository extends BaseDirectusRepository {
 			};
 		} catch (error) {
 			throw this.logAndWrapError(error, this.updatePartnerById.name);
-		}
-	}
-
-	/**
-	 * Persist the cached URL count on the website row (sitemap / listing).
-	 *
-	 * @param {{ slug: string; totalUrls: number }} input
-	 * @returns {Promise<{ id: string; totalUrls: number } | null>}
-	 */
-	async updatePartnerTotalUrls({ slug, totalUrls }) {
-		try {
-			const query = getQueryUpdatePartnerUrls(slug, totalUrls);
-			const raw = await this.client.query(query);
-			const row = raw.update_toolgankelijk_website_item ?? null;
-			if (!row) return null;
-			return {
-				id: row.id,
-				totalUrls
-			};
-		} catch (error) {
-			throw this.logAndWrapError(error, this.updatePartnerTotalUrls.name);
 		}
 	}
 

--- a/src/lib/server/repositories/partnerRepository.js
+++ b/src/lib/server/repositories/partnerRepository.js
@@ -164,7 +164,6 @@ export class PartnerRepository extends BaseDirectusRepository {
 			const query = getQueryUpdatePartner(name, slug, url, id);
 			const raw = await this.client.query(query);
 			const row = raw.update_toolgankelijk_website_item ?? null;
-			console.log(row);
 			if (!row) throw new Error(`Kon partner met ID '${id}' niet bijwerken.`);
 			return {
 				id: row.id,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -35,8 +35,7 @@
 			!$page.url.pathname.startsWith('/logout')
 	);
 
-
-    let dialogType = $derived($page.url.pathname === '/' ? 'addPartner' : 'addUrl');
+	let dialogType = $derived($page.url.pathname === '/' ? 'addPartner' : 'addUrl');
 
 	onNavigate((navigation) => {
 		if (!document.startViewTransition) return;
@@ -49,12 +48,11 @@
 		});
 	});
 
-
-
 	function openAddUrl() {
 		dialogRef?.open();
 	}
 </script>
+
 <Dialog bind:this={dialogRef} {params} isType={dialogType} />
 
 <Header />

--- a/src/routes/[websiteUID]/addUrl/+page.server.js
+++ b/src/routes/[websiteUID]/addUrl/+page.server.js
@@ -20,7 +20,7 @@ export const actions = {
 			const formData = await request.formData();
 			const name = formData.get('name').toLowerCase();
 			const formUrl = normalizeHttpUrl(formData.get('url'));
-			const formSlug =formData.get('slug');
+			const formSlug = formData.get('slug');
 
 			if (!name || !formUrl) {
 				return {

--- a/src/routes/api/addPartner/+server.js
+++ b/src/routes/api/addPartner/+server.js
@@ -63,7 +63,6 @@ export async function POST({ request }) {
 
 			if (toggle && urls.length) {
 				const { total } = await processUrls(urls, slug, pushProgressUpdateToClient);
-				await partnerRepository.updatePartnerTotalUrls({ slug, totalUrls: total });
 				await delay(1000);
 				for (const urlEntry of urls) {
 					const path = new URL(urlEntry).pathname;

--- a/src/routes/api/editPartner/+server.js
+++ b/src/routes/api/editPartner/+server.js
@@ -57,7 +57,6 @@ export async function POST({ request }) {
 
 			if (toggle && urls.length) {
 				const { total } = await processUrls(urls, slug, pushProgressUpdateToClient);
-				await partnerRepository.updatePartnerTotalUrls({ slug, totalUrls: total });
 				await delay(500);
 				for (const urlEntry of urls) {
 					const path = new URL(urlEntry).pathname;

--- a/tests/lib/server/repositories/partnerRepository.test.js
+++ b/tests/lib/server/repositories/partnerRepository.test.js
@@ -110,18 +110,6 @@ describe('PartnerRepository', () => {
 			});
 		});
 
-		it('returns null when mutation returns no row', async () => {
-			client.query.mockResolvedValue({ create_toolgankelijk_website_item: null });
-
-			const result = await repository.createPartner({
-				name: 'T',
-				url: 'https://h',
-				slug: 's'
-			});
-
-			expect(result).toBeNull();
-		});
-
 		it('throws RepositoryError on error', async () => {
 			const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 			client.query.mockRejectedValue(new Error());
@@ -158,19 +146,6 @@ describe('PartnerRepository', () => {
 			});
 		});
 
-		it('returns null when mutation returns no row', async () => {
-			client.query.mockResolvedValue({ update_toolgankelijk_website_item: null });
-
-			const result = await repository.updatePartnerById({
-				id: 'w1',
-				name: 'N',
-				url: 'https://n',
-				slug: 'ns'
-			});
-
-			expect(result).toBeNull();
-		});
-
 		it('throws RepositoryError on error', async () => {
 			const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 			client.query.mockRejectedValue(new Error());
@@ -183,36 +158,6 @@ describe('PartnerRepository', () => {
 					slug: 'ns'
 				})
 			).rejects.toThrow(RepositoryError);
-			spy.mockRestore();
-		});
-	});
-
-	describe('updatePartnerTotalUrls', () => {
-		it('returns id and totalUrls', async () => {
-			client.query.mockResolvedValue({
-				update_toolgankelijk_website_item: { id: 'w1' }
-			});
-
-			const result = await repository.updatePartnerTotalUrls({ slug: 's', totalUrls: 42 });
-
-			expect(result).toEqual({ id: 'w1', totalUrls: 42 });
-		});
-
-		it('returns null when mutation returns no row', async () => {
-			client.query.mockResolvedValue({ update_toolgankelijk_website_item: null });
-
-			await expect(
-				repository.updatePartnerTotalUrls({ slug: 's', totalUrls: 1 })
-			).resolves.toBeNull();
-		});
-
-		it('throws RepositoryError on error', async () => {
-			const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-			client.query.mockRejectedValue(new Error());
-
-			await expect(repository.updatePartnerTotalUrls({ slug: 's', totalUrls: 1 })).rejects.toThrow(
-				RepositoryError
-			);
 			spy.mockRestore();
 		});
 	});


### PR DESCRIPTION
## What does this change?

Currently, the websites table does not store totalurls, all functions that try to save to this field fail.
This PR removes code referring to the old totalurls implementation.
automated tests for errors have been updated

i also changed the returned error messages, for easier future debugging

## How Has This Been Tested?

2 automated tests have been updated

## How to review

check if automated tests work.
try to add and edit a partner.
